### PR TITLE
Sets babel-preset-travix to Stage 3 + required plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,21 @@
 const moduleExportsPlugin = require('babel-plugin-add-module-exports');
 const babelPresetEs2015 = require('babel-preset-es2015');
-const babelPresetStage0 = require('babel-preset-stage-0');
+const babelPresetStage3 = require('babel-preset-stage-3');
 const babelPresetReact = require('babel-preset-react');
+const babelPluginTransformExportDefault = require('babel-plugin-transform-export-default');
 const babelPluginTransformEs2015ObjectSuper = require('babel-plugin-transform-es2015-object-super');
+const babelPluginTransformFunctionBind = require('babel-plugin-transform-function-bind');
 
 module.exports = {
   presets: [
     babelPresetEs2015,
-    babelPresetStage0,
+    babelPresetStage3,
     babelPresetReact,
   ],
   plugins: [
     moduleExportsPlugin.default ? moduleExportsPlugin.default : moduleExportsPlugin,
     babelPluginTransformEs2015ObjectSuper,
+    babelPluginTransformExportDefault,
+    babelPluginTransformFunctionBind,
   ],
 };

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
   "dependencies": {
     "babel-plugin-add-module-exports": "^0.2.0",
     "babel-plugin-transform-es2015-object-super": "^6.3.13",
+    "babel-plugin-transform-export-default": "^7.0.0-alpha.20",
+    "babel-plugin-transform-function-bind": "^6.22.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13"
+    "babel-preset-stage-3": "^6.24.1"
   },
   "devDependencies": {
     "eslint": "^3.9.1",


### PR DESCRIPTION
# What does this PR do:

* Changes the Travix's preset to use Stage 3
* Adds 2 plugins, non-stage-3, required to maintain functionality at Travix.

# Where should the reviewer start:
  - Diffs