### PR TITLE
Add babel-plugin-transform-react-remove-prop-types

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ const babelPluginTransformClassProperties = require('babel-plugin-transform-clas
 const babelPluginTransformExportDefault = require('babel-plugin-transform-export-default');
 const babelPluginTransformEs2015ObjectSuper = require('babel-plugin-transform-es2015-object-super');
 const babelPluginTransformFunctionBind = require('babel-plugin-transform-function-bind');
+const babelPluginTransfromRemovePropTypes = require("babel-plugin-transform-react-remove-prop-types").default;
+
+const isProduction = process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'unstable';
 
 const targets = {
   node: 8,
@@ -29,5 +32,6 @@ module.exports = {
     babelPluginTransformEs2015ObjectSuper,
     babelPluginTransformExportDefault,
     babelPluginTransformFunctionBind,
-  ],
+    isProduction ? babelPluginTransfromRemovePropTypes : null,
+  ].filter(Boolean)
 };

--- a/index.js
+++ b/index.js
@@ -32,6 +32,6 @@ module.exports = {
     babelPluginTransformEs2015ObjectSuper,
     babelPluginTransformExportDefault,
     babelPluginTransformFunctionBind,
-    isProduction ? babelPluginTransfromRemovePropTypes : null,
+    isProduction && babelPluginTransfromRemovePropTypes,
   ].filter(Boolean)
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-plugin-transform-export-default": "^7.0.0-alpha.20",
     "babel-plugin-transform-function-bind": "^6.22.0",
     "babel-preset-env": "^1.6.1",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-3": "^6.24.1"
   },


### PR DESCRIPTION
# What:
Adds **babel-plugin-transform-react-remove-prop-types** plugin for removing unnecessary React propTypes from the production build.

![image](https://user-images.githubusercontent.com/14991709/37800440-d8f3ad94-2e33-11e8-8fcd-e22c63fe3efe.png)

I intentionally made an error in prop-types in 'Your searches' nav item. 
https://bitbucket.org/xivart/rwd_cheaptickets_nl/branch/FI-5-speed-up-optimize-building-and-bund#diff
https://fi-5-acceptance.vayama.com/


https://fi-5-acceptance.cheaptickets.nl/en - this version was built without 'NODE_ENV=production', so we can check that our other environments are unaffected and prop-types warnings are still displayed.
It proves that this babel-plugin works at least.


